### PR TITLE
[i18n] Fixed a plural index parsing bug

### DIFF
--- a/po/message.go
+++ b/po/message.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"strconv"
-	"strings"
 )
 
 // A PO file is made up of many entries,
@@ -131,8 +130,13 @@ func (p *Message) readMsgStrOrPlural(r *lineReader) (err error) {
 		return
 	}
 	if reMsgStrPlural.MatchString(s) {
-		left, right := strings.Index(s, `[`), strings.LastIndex(s, `]`)
-		idx, _ := strconv.Atoi(s[left+1 : right])
+		names := reMsgStrPlural.SubexpNames()
+		result := reMsgStrPlural.FindAllStringSubmatch(s, -1)
+		m := map[string]string{}
+		for i, n := range result[0] {
+			m[names[i]] = n
+		}
+		idx, _ := strconv.Atoi(m["index"])
 		s, err = p.readString(r)
 		if n := len(p.MsgStrPlural); (idx + 1) > n {
 			p.MsgStrPlural = append(p.MsgStrPlural, make([]string, (idx+1)-n)...)

--- a/po/message_test.go
+++ b/po/message_test.go
@@ -24,6 +24,40 @@ func _TestPoEntry(t *testing.T) {
 	}
 }
 
+// The original msgPlural entry index parsing simply parses the content within the first "[" and last "]". This logic is
+// wrong because the string itself can contain square brackets e.g "msgstr[0] Hello world [Here is text within brackets]"
+// This test case is for capturing regressions like this.
+func TestPluralParsing(t *testing.T) {
+	var entry Message
+	if err := entry.readPoEntry(newLineReader(pluralPoEntryString)); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(entry.MsgStrPlural) != 2 {
+		t.Fail()
+	}
+
+	if entry.MsgStrPlural[0] != "Baix[1]ar CSV [{%2=warehouse name}] ({%1=number of products} linha)" {
+		t.Fail()
+	}
+
+	if entry.MsgStrPlural[1] != "Baix[2]ar CSV [{%2=warehouse name}] ({%1=number of products} linhas)" {
+		t.Fail()
+	}
+}
+
+var pluralPoEntryString = `
+# SOURCE: JAVASCRIPT
+#. File Name: /builds/ContextLogic/clroot/sweeper/merchant_dashboard/static/js/pkg/merchant/component/products/all-products/HeaderRow.tsx
+msgctxt "NAME OF BUTTON MERCHANTS CAN CLICK TO DOWNLOAD ALL THEIR PRODUCTS AS AN CSV "
+"FILE. INCLUDED IS THE NAME OF THE WAREHOUSE AND THE NUMBER OF ROWS THAT WILL "
+"BE IN THE FILE."
+msgid "Download CSV [{%2=warehouse name}] ({%1=number of products} row)"
+msgid_plural "Download CSV [{%2=warehouse name}] ({%1=number of products} rows)"
+msgstr	[0] "Baix[1]ar CSV [{%2=warehouse name}] ({%1=number of products} linha)"
+msgstr		[1] "Baix[2]ar CSV [{%2=warehouse name}] ({%1=number of products} linhas)"
+`
+
 var testPoEntryStrings = []string{
 	`
 # SOME DESCRIPTIVE TITLE.

--- a/po/re.go
+++ b/po/re.go
@@ -21,7 +21,7 @@ var (
 	reMsgId        = regexp.MustCompile(`^msgid\s+".*"\s*$`)              // msgid
 	reMsgIdPlural  = regexp.MustCompile(`^msgid_plural\s+".*"\s*$`)       // msgid_plural
 	reMsgStr       = regexp.MustCompile(`^msgstr\s*".*"\s*$`)             // msgstr
-	reMsgStrPlural = regexp.MustCompile(`^msgstr\s*(\[\d+\])\s*".*"\s*$`) // msgstr[0]
+	reMsgStrPlural = regexp.MustCompile(`^msgstr\s*(\[(?P<index>\d+)\])\s*".*"\s*$`) // msgstr[0]
 	reStringLine   = regexp.MustCompile(`^\s*".*"\s*$`)                   // "message"
 	reBlankLine    = regexp.MustCompile(`^\s*$`)                          //
 )


### PR DESCRIPTION
### Notes 
This is for fixing a plural index parsing bug. 

When parsing:
```
# SOURCE: JAVASCRIPT
#. File Name: /builds/ContextLogic/clroot/sweeper/merchant_dashboard/static/js/pkg/merchant/component/products/all-products/HeaderRow.tsx
msgctxt "NAME OF BUTTON MERCHANTS CAN CLICK TO DOWNLOAD ALL THEIR PRODUCTS AS AN CSV "
"FILE. INCLUDED IS THE NAME OF THE WAREHOUSE AND THE NUMBER OF ROWS THAT WILL "
"BE IN THE FILE."
msgid "Download CSV [{%2=warehouse name}] ({%1=number of products} row)"
msgid_plural "Download CSV [{%2=warehouse name}] ({%1=number of products} rows)"
msgstr	[0] "Baix[1]ar CSV [{%2=warehouse name}] ({%1=number of products} linha)"
msgstr		[1] "Baix[2]ar CSV [{%2=warehouse name}] ({%1=number of products} linhas)"
```

The `msgPlural` entry would contain one entry, however, it's expected to contain 2 entries. This is causing the this [job](https://gitlab.i.wish.com/ContextLogic/clroot/-/jobs/7267894) to fail. 